### PR TITLE
Compatibility module for Trickster

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,6 +84,9 @@ dependencies {
 
 	annotationProcessor modApi("io.wispforest:owo-lib:${property('deps.owo-lib')}")
 	include "io.wispforest:owo-sentinel:${property('deps.owo-lib')}"
+
+	//TODO: make this modCompileOnly
+	modImplementation "dev.enjarai:trickster:${property('deps.trickster')}"
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -31,3 +31,6 @@ deps.fantasy=0.6.4+1.21
 deps.map_api=0.4.2+1.21.1
 
 deps.owo-lib=0.12.11+1.21
+
+# Optional
+deps.trickster=2.0.0-alpha.32

--- a/src/main/java/dev/enjarai/minitardis/MiniTardis.java
+++ b/src/main/java/dev/enjarai/minitardis/MiniTardis.java
@@ -3,6 +3,7 @@ package dev.enjarai.minitardis;
 import dev.enjarai.minitardis.block.ModBlocks;
 import dev.enjarai.minitardis.canvas.TardisCanvasUtils;
 import dev.enjarai.minitardis.command.TardisCommand;
+import dev.enjarai.minitardis.compat.trickster.TricksterCompatModule;
 import dev.enjarai.minitardis.component.Tardis;
 import dev.enjarai.minitardis.component.screen.app.ScreenAppTypes;
 import dev.enjarai.minitardis.item.ModDataComponents;
@@ -17,7 +18,6 @@ import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.Version;
 import net.minecraft.resource.ResourceType;
 import net.minecraft.server.MinecraftServer;
-import net.minecraft.server.network.ServerPlayNetworkHandler;
 import net.minecraft.util.Identifier;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
@@ -60,6 +60,11 @@ public class MiniTardis implements ModInitializer {
 		// Load screenapps and their loot tables in order
 		ScreenAppTypes.load();
 		ModDataStuff.load();
+
+		// If Trickster is loaded, also load the Trickster compatibility module
+		if (FabricLoader.getInstance().isModLoaded("trickster")) {
+			TricksterCompatModule.load();
+		}
 	}
 
 	@Nullable

--- a/src/main/java/dev/enjarai/minitardis/compat/trickster/GuardingSpellApp.java
+++ b/src/main/java/dev/enjarai/minitardis/compat/trickster/GuardingSpellApp.java
@@ -1,0 +1,72 @@
+package dev.enjarai.minitardis.compat.trickster;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import dev.enjarai.minitardis.block.console.ScreenBlockEntity;
+import dev.enjarai.minitardis.canvas.TardisCanvasUtils;
+import dev.enjarai.minitardis.component.Tardis;
+import dev.enjarai.minitardis.component.TardisControl;
+import dev.enjarai.minitardis.component.screen.app.*;
+import dev.enjarai.minitardis.component.screen.canvas.CanvasColors;
+import dev.enjarai.minitardis.component.screen.canvas.patbox.DrawableCanvas;
+import dev.enjarai.trickster.spell.Fragment;
+import dev.enjarai.trickster.spell.SpellPart;
+import dev.enjarai.trickster.spell.execution.executor.DefaultSpellExecutor;
+import dev.enjarai.trickster.spell.fragment.VoidFragment;
+import io.wispforest.accessories.endec.CodecUtils;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.ClickType;
+
+import java.util.List;
+import java.util.Optional;
+
+public class GuardingSpellApp implements ScreenApp {
+    public static final Codec<GuardingSpellApp> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+            CodecUtils.ofEndec(DefaultSpellExecutor.ENDEC).optionalFieldOf("spell").forGetter(app -> Optional.of(app.spell)),
+            CodecUtils.ofEndec(Fragment.ENDEC).optionalFieldOf("crow_mind").forGetter(app -> Optional.of(app.crowMind))
+    ).apply(instance, GuardingSpellApp::new));
+    public static final ScreenAppType<GuardingSpellApp> TYPE =
+            new ScreenAppType<>(MapCodec.assumeMapUnsafe(GuardingSpellApp.CODEC), GuardingSpellApp::new, false);
+
+    public final DefaultSpellExecutor spell;
+    public Fragment crowMind;
+
+    public GuardingSpellApp(Optional<DefaultSpellExecutor> spell, Optional<Fragment> crowMind) {
+        this.spell = spell.orElse(new DefaultSpellExecutor(new SpellPart(), List.of()));
+        this.crowMind = crowMind.orElse(VoidFragment.INSTANCE);
+    }
+
+    public GuardingSpellApp() {
+        this(Optional.empty(), Optional.empty());
+    }
+
+    @Override
+    public AppView getView(TardisControl controls) {
+        return new AppView() {
+            @Override
+            public void draw(ScreenBlockEntity blockEntity, DrawableCanvas canvas) {
+                TardisCanvasUtils.drawCenteredText(canvas, "This app does not implement a screen", 64, 40, CanvasColors.WHITE);
+            }
+
+            @Override
+            public boolean onClick(ScreenBlockEntity blockEntity, ServerPlayerEntity player, ClickType type, int x, int y) {
+                return false;
+            }
+        };
+    }
+
+    @Override
+    public void tardisTick(Tardis tardis) {
+        var state = tardis.getState();
+
+        if (state.isPowered(tardis) && state.isSolid(tardis)) {
+            spell.run(new TardisSpellSource(tardis, this));
+        }
+    }
+
+    @Override
+    public ScreenAppType<?> getType() {
+        return TYPE;
+    }
+}

--- a/src/main/java/dev/enjarai/minitardis/compat/trickster/GuardingSpellApp.java
+++ b/src/main/java/dev/enjarai/minitardis/compat/trickster/GuardingSpellApp.java
@@ -1,8 +1,6 @@
 package dev.enjarai.minitardis.compat.trickster;
 
-import com.mojang.serialization.Codec;
 import com.mojang.serialization.MapCodec;
-import com.mojang.serialization.codecs.RecordCodecBuilder;
 import dev.enjarai.minitardis.block.console.ScreenBlockEntity;
 import dev.enjarai.minitardis.canvas.TardisCanvasUtils;
 import dev.enjarai.minitardis.component.Tardis;
@@ -15,6 +13,8 @@ import dev.enjarai.trickster.spell.SpellPart;
 import dev.enjarai.trickster.spell.execution.executor.DefaultSpellExecutor;
 import dev.enjarai.trickster.spell.fragment.VoidFragment;
 import io.wispforest.accessories.endec.CodecUtils;
+import io.wispforest.endec.Endec;
+import io.wispforest.endec.impl.StructEndecBuilder;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.ClickType;
 
@@ -22,12 +22,13 @@ import java.util.List;
 import java.util.Optional;
 
 public class GuardingSpellApp implements ScreenApp {
-    public static final Codec<GuardingSpellApp> CODEC = RecordCodecBuilder.create(instance -> instance.group(
-            CodecUtils.ofEndec(DefaultSpellExecutor.ENDEC).optionalFieldOf("spell").forGetter(app -> Optional.of(app.spell)),
-            CodecUtils.ofEndec(Fragment.ENDEC).optionalFieldOf("crow_mind").forGetter(app -> Optional.of(app.crowMind))
-    ).apply(instance, GuardingSpellApp::new));
+    public static final Endec<GuardingSpellApp> ENDEC = StructEndecBuilder.of(
+            DefaultSpellExecutor.ENDEC.optionalOf().fieldOf("spell", app -> Optional.of(app.spell)),
+            Fragment.ENDEC.optionalOf().fieldOf("crow_mind", app -> Optional.of(app.crowMind)),
+            GuardingSpellApp::new
+    );
     public static final ScreenAppType<GuardingSpellApp> TYPE =
-            new ScreenAppType<>(MapCodec.assumeMapUnsafe(GuardingSpellApp.CODEC), GuardingSpellApp::new, false);
+            new ScreenAppType<>(MapCodec.assumeMapUnsafe(CodecUtils.ofEndec(GuardingSpellApp.ENDEC)), GuardingSpellApp::new, false);
 
     public final DefaultSpellExecutor spell;
     public Fragment crowMind;

--- a/src/main/java/dev/enjarai/minitardis/compat/trickster/TardisSpellSource.java
+++ b/src/main/java/dev/enjarai/minitardis/compat/trickster/TardisSpellSource.java
@@ -1,0 +1,90 @@
+package dev.enjarai.minitardis.compat.trickster;
+
+import dev.enjarai.minitardis.component.Tardis;
+import dev.enjarai.trickster.spell.Fragment;
+import dev.enjarai.trickster.spell.execution.source.SpellSource;
+import dev.enjarai.trickster.spell.mana.ManaPool;
+import dev.enjarai.trickster.spell.mana.ManaPoolType;
+import net.minecraft.server.world.ServerWorld;
+import org.jetbrains.annotations.Nullable;
+import org.joml.Vector3d;
+import org.ladysnake.cca.api.v3.component.Component;
+import org.ladysnake.cca.api.v3.component.ComponentKey;
+
+import java.util.Optional;
+
+public class TardisSpellSource extends SpellSource {
+    public final Tardis tardis;
+    public final GuardingSpellApp app;
+
+    public TardisSpellSource(Tardis tardis, GuardingSpellApp app) {
+        this.tardis = tardis;
+        this.app = app;
+    }
+
+    @Override
+    public ManaPool getManaPool() {
+        return new ManaPool() {
+            @Override
+            @Nullable
+            public ManaPoolType<?> type() {
+                return null;
+            }
+
+            @Override
+            public void set(float value) {
+                tardis.addOrDrainFuel(Math.round(value));
+            }
+
+            @Override
+            public float get() {
+                return tardis.getFuel();
+            }
+
+            @Override
+            public float getMax() {
+                return 1000;
+            }
+        };
+    }
+
+    @Override
+    public <T extends Component> Optional<T> getComponent(ComponentKey<T> key) {
+        return Optional.empty();
+    }
+
+    @Override
+    public float getHealth() {
+        return 30;
+    }
+
+    @Override
+    public float getMaxHealth() {
+        return 30;
+    }
+
+    @Override
+    public Vector3d getPos() {
+        return tardis.getCurrentLandedLocation()
+                .orElseThrow(() -> new IllegalStateException("Spell attempted to acquire TARDIS location while not landed; spell execution is not permitted during flight"))
+                .pos()
+                .toCenterPos()
+                .toVector3d();
+    }
+
+    @Override
+    public ServerWorld getWorld() {
+        return tardis.getExteriorWorld()
+                .orElseThrow(() -> new IllegalStateException("Spell attempted to acquire TARDIS exterior world while not landed; spell execution is not permitted during flight"));
+    }
+
+    @Override
+    public Fragment getCrowMind() {
+        return app.crowMind;
+    }
+
+    @Override
+    public void setCrowMind(Fragment fragment) {
+        app.crowMind = fragment;
+    }
+}

--- a/src/main/java/dev/enjarai/minitardis/compat/trickster/TricksterCompatModule.java
+++ b/src/main/java/dev/enjarai/minitardis/compat/trickster/TricksterCompatModule.java
@@ -1,0 +1,13 @@
+package dev.enjarai.minitardis.compat.trickster;
+
+import dev.enjarai.minitardis.MiniTardis;
+import dev.enjarai.minitardis.component.screen.app.ScreenAppType;
+import net.minecraft.registry.Registry;
+
+public class TricksterCompatModule {
+    public static void load() {
+        Registry.register(ScreenAppType.REGISTRY,
+                MiniTardis.id("guarding_spell"),
+                GuardingSpellApp.TYPE);
+    }
+}


### PR DESCRIPTION
Meant to add a way to run spells off the TARDIS fuel, but attempting to acquire the app causes a client disconnect due to packet parsing failure.

I've marked Trickster as `modImplementation` because I'm lazy, be sure to change it to `modCompileOnly` before merging.