### PR TITLE
Use MapCodec for apps.

### DIFF
--- a/src/main/java/dev/enjarai/minitardis/component/screen/app/BadAppleApp.java
+++ b/src/main/java/dev/enjarai/minitardis/component/screen/app/BadAppleApp.java
@@ -1,6 +1,6 @@
 package dev.enjarai.minitardis.component.screen.app;
 
-import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
 import dev.enjarai.minitardis.ModSounds;
 import dev.enjarai.minitardis.block.console.ScreenBlockEntity;
 import dev.enjarai.minitardis.canvas.BadApple;
@@ -15,7 +15,7 @@ import net.minecraft.util.ClickType;
 import net.minecraft.util.math.MathHelper;
 
 public class BadAppleApp implements ScreenApp {
-    public static final Codec<BadAppleApp> CODEC = Codec.unit(BadAppleApp::new);
+    public static final MapCodec<BadAppleApp> CODEC = MapCodec.unit(BadAppleApp::new);
     public static final short[] COLORS = new short[] {
             CanvasUtils.toLimitedColor(0x111111),
             CanvasUtils.toLimitedColor(0x333333),

--- a/src/main/java/dev/enjarai/minitardis/component/screen/app/DimensionsApp.java
+++ b/src/main/java/dev/enjarai/minitardis/component/screen/app/DimensionsApp.java
@@ -1,6 +1,6 @@
 package dev.enjarai.minitardis.component.screen.app;
 
-import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import dev.enjarai.minitardis.block.console.ScreenBlockEntity;
 import dev.enjarai.minitardis.canvas.TardisCanvasUtils;
@@ -28,7 +28,7 @@ import java.util.Comparator;
 import java.util.List;
 
 public class DimensionsApp implements ScreenApp {
-    public static final Codec<DimensionsApp> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+    public static final MapCodec<DimensionsApp> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
             RegistryKey.createCodec(RegistryKeys.WORLD).listOf().optionalFieldOf("accessible_dimensions", List.of()).forGetter(app -> app.accessibleDimensions)
     ).apply(instance, DimensionsApp::new));
 

--- a/src/main/java/dev/enjarai/minitardis/component/screen/app/DummyApp.java
+++ b/src/main/java/dev/enjarai/minitardis/component/screen/app/DummyApp.java
@@ -1,6 +1,6 @@
 package dev.enjarai.minitardis.component.screen.app;
 
-import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
 import dev.enjarai.minitardis.block.console.ScreenBlockEntity;
 import dev.enjarai.minitardis.canvas.TardisCanvasUtils;
 import dev.enjarai.minitardis.component.TardisControl;
@@ -10,7 +10,7 @@ import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.ClickType;
 
 public class DummyApp implements ScreenApp {
-    public static final Codec<DummyApp> CODEC = Codec.unit(DummyApp::new);
+    public static final MapCodec<DummyApp> CODEC = MapCodec.unit(DummyApp::new);
 
     @Override
     public AppView getView(TardisControl controls) {

--- a/src/main/java/dev/enjarai/minitardis/component/screen/app/FloppyBirdApp.java
+++ b/src/main/java/dev/enjarai/minitardis/component/screen/app/FloppyBirdApp.java
@@ -3,6 +3,7 @@ package dev.enjarai.minitardis.component.screen.app;
 import com.mojang.authlib.GameProfile;
 import com.mojang.datafixers.util.Pair;
 import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import dev.enjarai.minitardis.block.console.ScreenBlockEntity;
 import dev.enjarai.minitardis.canvas.TardisCanvasUtils;
@@ -28,7 +29,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.*;
 
 public class FloppyBirdApp implements ScreenApp {
-    public static final Codec<FloppyBirdApp> CODEC = RecordCodecBuilder.<FloppyBirdApp>create(instance -> instance.group(
+    public static final MapCodec<FloppyBirdApp> CODEC = RecordCodecBuilder.<FloppyBirdApp>mapCodec(instance -> instance.group(
             Codec.unboundedMap(Uuids.STRING_CODEC, Codec.INT).optionalFieldOf("high_scores", Map.of()).<FloppyBirdApp>forGetter(app -> app.highScores)
     ).<FloppyBirdApp>apply(instance, FloppyBirdApp::new));
     public static final int WIN_DURATION = 30;

--- a/src/main/java/dev/enjarai/minitardis/component/screen/app/GpsApp.java
+++ b/src/main/java/dev/enjarai/minitardis/component/screen/app/GpsApp.java
@@ -1,7 +1,7 @@
 package dev.enjarai.minitardis.component.screen.app;
 
 import com.mojang.datafixers.util.Either;
-import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
 import dev.enjarai.minitardis.block.console.ScreenBlockEntity;
 import dev.enjarai.minitardis.canvas.TardisCanvasUtils;
 import dev.enjarai.minitardis.component.PartialTardisLocation;
@@ -17,7 +17,7 @@ import java.util.Optional;
 
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 public class GpsApp implements ScreenApp {
-    public static final Codec<GpsApp> CODEC = Codec.unit(GpsApp::new);
+    public static final MapCodec<GpsApp> CODEC = MapCodec.unit(GpsApp::new);
 
     @Override
     public AppView getView(TardisControl controls) {

--- a/src/main/java/dev/enjarai/minitardis/component/screen/app/HistoryApp.java
+++ b/src/main/java/dev/enjarai/minitardis/component/screen/app/HistoryApp.java
@@ -1,7 +1,7 @@
 package dev.enjarai.minitardis.component.screen.app;
 
 import com.google.common.collect.Iterables;
-import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import dev.enjarai.minitardis.block.console.ScreenBlockEntity;
 import dev.enjarai.minitardis.canvas.TardisCanvasUtils;
@@ -22,7 +22,7 @@ import java.util.Optional;
 import java.util.function.Consumer;
 
 public class HistoryApp implements ScreenApp {
-    public static final Codec<HistoryApp> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+    public static final MapCodec<HistoryApp> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
             HistoryEntry.CODEC.listOf().optionalFieldOf("history", List.of()).forGetter(app -> app.history)
     ).apply(instance, HistoryApp::new));
     private static final int ENTRIES_PER_PAGE = 3;

--- a/src/main/java/dev/enjarai/minitardis/component/screen/app/InterdictorApp.java
+++ b/src/main/java/dev/enjarai/minitardis/component/screen/app/InterdictorApp.java
@@ -1,6 +1,7 @@
 package dev.enjarai.minitardis.component.screen.app;
 
 import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import dev.enjarai.minitardis.block.console.ScreenBlockEntity;
 import dev.enjarai.minitardis.canvas.TardisCanvasUtils;
@@ -15,7 +16,7 @@ import dev.enjarai.minitardis.component.screen.element.ThreeSelectElement;
 import net.minecraft.util.math.Direction;
 
 public class InterdictorApp implements ScreenApp {
-    public static final Codec<InterdictorApp> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+    public static final MapCodec<InterdictorApp> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
             Codec.INT.optionalFieldOf("selected_wave_part", 0).forGetter(app -> app.selectedWavePart),
             FlightWave.CODEC.optionalFieldOf("selected_wave", new FlightWave(0.5, 0.5, 0.5)).forGetter(app -> app.selectedWave)
     ).apply(instance, InterdictorApp::new));

--- a/src/main/java/dev/enjarai/minitardis/component/screen/app/LookAndFeelApp.java
+++ b/src/main/java/dev/enjarai/minitardis/component/screen/app/LookAndFeelApp.java
@@ -1,6 +1,7 @@
 package dev.enjarai.minitardis.component.screen.app;
 
 import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import dev.enjarai.minitardis.block.console.ScreenBlockEntity;
 import dev.enjarai.minitardis.canvas.TardisCanvasUtils;
@@ -22,7 +23,7 @@ import java.util.Arrays;
 import java.util.stream.IntStream;
 
 public class LookAndFeelApp implements ScreenApp {
-    public static final Codec<LookAndFeelApp> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+    public static final MapCodec<LookAndFeelApp> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
             Codec.INT_STREAM.optionalFieldOf("history", IntStream.empty()).forGetter(app -> IntStream.of(app.history))
     ).apply(instance, LookAndFeelApp::new));
 

--- a/src/main/java/dev/enjarai/minitardis/component/screen/app/PackageManagerApp.java
+++ b/src/main/java/dev/enjarai/minitardis/component/screen/app/PackageManagerApp.java
@@ -1,6 +1,6 @@
 package dev.enjarai.minitardis.component.screen.app;
 
-import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
 import dev.enjarai.minitardis.block.console.ScreenBlockEntity;
 import dev.enjarai.minitardis.canvas.TardisCanvasUtils;
 import dev.enjarai.minitardis.component.TardisControl;
@@ -13,7 +13,7 @@ import dev.enjarai.minitardis.item.FloppyItem;
 import net.minecraft.item.ItemStack;
 
 public class PackageManagerApp implements ScreenApp {
-    public static final Codec<PackageManagerApp> CODEC = Codec.unit(PackageManagerApp::new);
+    public static final MapCodec<PackageManagerApp> CODEC = MapCodec.unit(PackageManagerApp::new);
 
     @Override
     public AppView getView(TardisControl controls) {

--- a/src/main/java/dev/enjarai/minitardis/component/screen/app/ScannerApp.java
+++ b/src/main/java/dev/enjarai/minitardis/component/screen/app/ScannerApp.java
@@ -1,6 +1,6 @@
 package dev.enjarai.minitardis.component.screen.app;
 
-import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
 import dev.enjarai.minitardis.block.console.ScreenBlockEntity;
 import dev.enjarai.minitardis.canvas.TardisCanvasUtils;
 import dev.enjarai.minitardis.component.DestinationScanner;
@@ -14,7 +14,7 @@ import net.minecraft.block.MapColor;
 import net.minecraft.util.math.ColorHelper;
 
 public class ScannerApp implements ScreenApp {
-    public static final Codec<ScannerApp> CODEC = Codec.unit(ScannerApp::new);
+    public static final MapCodec<ScannerApp> CODEC = MapCodec.unit(ScannerApp::new);
 
     @Override
     public AppView getView(TardisControl controls) {

--- a/src/main/java/dev/enjarai/minitardis/component/screen/app/ScreenAppTypes.java
+++ b/src/main/java/dev/enjarai/minitardis/component/screen/app/ScreenAppTypes.java
@@ -1,6 +1,5 @@
 package dev.enjarai.minitardis.component.screen.app;
 
-import com.mojang.serialization.Codec;
 import com.mojang.serialization.MapCodec;
 import dev.enjarai.minitardis.MiniTardis;
 import net.minecraft.registry.Registry;
@@ -22,11 +21,11 @@ public class ScreenAppTypes {
     public static final ScreenAppType<FloppyBirdApp> FLOPPY_BIRD = register("floppy_bird", FloppyBirdApp.CODEC, FloppyBirdApp::new, true);
     public static final ScreenAppType<InterdictorApp> INTERDICTOR = register("interdictor", InterdictorApp.CODEC, InterdictorApp::new, true);
 
-    private static <T extends ScreenApp> ScreenAppType<T> register(String name, Codec<T> codec, Supplier<T> constructor, boolean spawnsAsDungeonLoot) {
-        return Registry.register(ScreenAppType.REGISTRY, MiniTardis.id(name), new ScreenAppType<>(MapCodec.assumeMapUnsafe(codec), constructor, spawnsAsDungeonLoot));
+    private static <T extends ScreenApp> ScreenAppType<T> register(String name, MapCodec<T> codec, Supplier<T> constructor, boolean spawnsAsDungeonLoot) {
+        return Registry.register(ScreenAppType.REGISTRY, MiniTardis.id(name), new ScreenAppType<>(codec, constructor, spawnsAsDungeonLoot));
     }
 
-    private static <T extends ScreenApp> ScreenAppType<T> register(String name, Codec<T> codec, Supplier<T> constructor) {
+    private static <T extends ScreenApp> ScreenAppType<T> register(String name, MapCodec<T> codec, Supplier<T> constructor) {
         return register(name, codec, constructor, false);
     }
 

--- a/src/main/java/dev/enjarai/minitardis/component/screen/app/SnakeApp.java
+++ b/src/main/java/dev/enjarai/minitardis/component/screen/app/SnakeApp.java
@@ -1,6 +1,6 @@
 package dev.enjarai.minitardis.component.screen.app;
 
-import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
 import dev.enjarai.minitardis.ModSounds;
 import dev.enjarai.minitardis.block.console.ScreenBlockEntity;
 import dev.enjarai.minitardis.canvas.TardisCanvasUtils;
@@ -19,7 +19,7 @@ import net.minecraft.util.math.random.Random;
 import org.joml.Vector2i;
 
 public class SnakeApp implements ScreenApp {
-    public static final Codec<SnakeApp> CODEC = Codec.unit(SnakeApp::new);
+    public static final MapCodec<SnakeApp> CODEC = MapCodec.unit(SnakeApp::new);
 
     @Override
     public AppView getView(TardisControl controls) {

--- a/src/main/java/dev/enjarai/minitardis/component/screen/app/StatusApp.java
+++ b/src/main/java/dev/enjarai/minitardis/component/screen/app/StatusApp.java
@@ -1,6 +1,6 @@
 package dev.enjarai.minitardis.component.screen.app;
 
-import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
 import dev.enjarai.minitardis.block.console.ScreenBlockEntity;
 import dev.enjarai.minitardis.canvas.TardisCanvasUtils;
 import dev.enjarai.minitardis.component.TardisControl;
@@ -21,7 +21,7 @@ import net.minecraft.util.math.random.Random;
 import java.util.Arrays;
 
 public class StatusApp implements ScreenApp {
-    public static final Codec<StatusApp> CODEC = Codec.unit(StatusApp::new);
+    public static final MapCodec<StatusApp> CODEC = MapCodec.unit(StatusApp::new);
 
     private final Random etaRandom = new LocalRandom(0);
 

--- a/src/main/java/dev/enjarai/minitardis/component/screen/app/WaypointsApp.java
+++ b/src/main/java/dev/enjarai/minitardis/component/screen/app/WaypointsApp.java
@@ -1,6 +1,7 @@
 package dev.enjarai.minitardis.component.screen.app;
 
 import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import dev.enjarai.minitardis.block.console.ScreenBlockEntity;
 import dev.enjarai.minitardis.canvas.TardisCanvasUtils;
@@ -30,7 +31,7 @@ import java.util.Map;
 import java.util.Optional;
 
 public class WaypointsApp implements ScreenApp {
-    public static final Codec<WaypointsApp> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+    public static final MapCodec<WaypointsApp> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
             Codec.unboundedMap(Codec.STRING.xmap(Integer::parseInt, Object::toString), TardisLocation.CODEC).optionalFieldOf("waypoints", Map.of()).forGetter(app -> app.waypoints)
     ).apply(instance, WaypointsApp::new));
 


### PR DESCRIPTION
This fixes crash when floppy is shift-clicked out of inventories and prevents creative players from being kicked when they have floppies in their inventory.
Closes #31